### PR TITLE
Polygon parser improvements

### DIFF
--- a/src/scad.c
+++ b/src/scad.c
@@ -1044,7 +1044,7 @@ static bool polygon_from_item(
         cp_v_nth(&r->points, i).loc = cp_v_nth(&points->value, i)->loc;
     }
 
-    if (_paths == NULL) {
+    if (_paths == NULL || (evaluate(_paths) == value_undef)) {
         cp_v_init0(&r->paths, 1);
         cp_v_init0(&cp_v_nth(&r->paths, 0).points, r->points.size);
         for (cp_v_each(j, &r->points)) {

--- a/src/scad.c
+++ b/src/scad.c
@@ -1017,11 +1017,13 @@ static bool polygon_from_item(
 
     cp_syn_value_t const *_points = NULL;
     cp_syn_value_t const *_paths = NULL;
+    cp_f_t _convexity;
 
     if (!GET_ARG(t, f->loc, &f->arg,
         (
             PARAM_RAW ("points", &_points, NULL),
             PARAM_RAW ("paths",  &_paths,  ((bool[]){false})),
+            PARAM_FLOAT ("convexity", &_convexity, NULL),
         ),
         ()))
     {


### PR DESCRIPTION
In current openscad (git version) as well as OpenSCAD version 2015.03-2 (debian stretch's version), the following input
```
linear_extrude()
    polygon(points=[ [0,0], [1,0], [0,1] ]);
```
is converted to this .csg output:
```
linear_extrude(height = 100, center = false, convexity = 1, scale = [1, 1], $fn = 0, $fa = 12, $fs = 2) {
	polygon(points = [[0, 0], [1, 0], [0, 1]], paths = undef, convexity = 1);
}
```

Both `paths = undef` and `convexity = 1` caused trouble in hob3l.  This PR allows hob3l to parse the output from openscad.